### PR TITLE
Enable or disable ActiveDirectoryAutoConfiguration based on the presence of spring environment property 'security.activedirectory.enabled' to have the possibility to deactivate the auto configuration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>de.dm.auth</groupId>
     <artifactId>activedirectory-spring-boot-starter</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0</version>
     <packaging>jar</packaging>
 
     <name>Activedirectory Spring Boot Starter</name>
@@ -54,6 +54,7 @@
         <asciidoctorj.pdf.version>1.5.0-alpha.16</asciidoctorj.pdf.version>
         <asciidoctorj.version>1.5.7</asciidoctorj.version>
         <spring-boot.version>2.0.6.RELEASE</spring-boot.version>
+        <assertj-core.version>3.9.1</assertj-core.version>
 
         <sonar.exclusions>**/*Config*,**/*Properties*,**/Hotfix*</sonar.exclusions>
     </properties>
@@ -91,6 +92,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -78,6 +78,7 @@ include::{project-basedir}/src/main/resources/ehcache.xml[]
 |===
 |Name|Type|Default value|Description
 
+|**security.activedirectory.enabled**|`java.lang.Boolean`|`true`|Enable or disable the auto configuration.
 |**security.activedirectory.cache-enabled**|`java.lang.Boolean`|`true`|Enable caching of authentication.
 |**security.activedirectory.domain**|`java.lang.String`|`SAMPLE.INC`|The AD domain that users authenticate against.
 |**security.activedirectory.url**|`java.lang.String`|`ldaps://sample:636`|URL that points to an ActiveDirectory instance. Multiple URLs can be provided, separated by a single whitespace character.

--- a/src/main/java/de/dm/auth/activedirectory/ActiveDirectoryAutoConfiguration.java
+++ b/src/main/java/de/dm/auth/activedirectory/ActiveDirectoryAutoConfiguration.java
@@ -4,6 +4,7 @@ import de.dm.auth.activedirectory.cache.AuthenticationCacheKeyGenerator;
 import de.dm.auth.activedirectory.cache.CachingAuthenticationProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.annotation.EnableCaching;
@@ -19,6 +20,7 @@ import org.springframework.security.ldap.authentication.ad.Hotfix3960ActiveDirec
 @Configuration
 @EnableCaching
 @EnableConfigurationProperties(ActiveDirectoryProperties.class)
+@ConditionalOnProperty(prefix = ActiveDirectoryProperties.ACTIVEDIRECTORY_PROPERTIES_PREFIX, name = "enabled", havingValue = "true", matchIfMissing = true)
 public class ActiveDirectoryAutoConfiguration {
 
     @Autowired

--- a/src/test/java/de/dm/auth/activedirectory/ActiveDirectoryAutoConfigurationTest.java
+++ b/src/test/java/de/dm/auth/activedirectory/ActiveDirectoryAutoConfigurationTest.java
@@ -1,0 +1,34 @@
+package de.dm.auth.activedirectory;
+
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+public class ActiveDirectoryAutoConfigurationTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(ActiveDirectoryAutoConfiguration.class, CacheAutoConfiguration.class));
+
+    @Test
+    public void enable_ActiveDirectoryAutoConfiguration_if_property_enabled_is_missing() {
+        this.contextRunner.run((context) -> {
+            assertThat(context).hasSingleBean(ActiveDirectoryAutoConfiguration.class);
+        });
+    }
+
+    @Test
+    public void enable_ActiveDirectoryAutoConfiguration_if_property_enabled_has_the_value_true() {
+        this.contextRunner.withPropertyValues(ActiveDirectoryProperties.ACTIVEDIRECTORY_PROPERTIES_PREFIX + ".enabled=true").run((context) -> {
+            assertThat(context).hasSingleBean(ActiveDirectoryAutoConfiguration.class);
+        });
+    }
+
+    @Test
+    public void disable_ActiveDirectoryAutoConfiguration_if_property_enabled_has_NOT_the_value_true() {
+        this.contextRunner.withPropertyValues(ActiveDirectoryProperties.ACTIVEDIRECTORY_PROPERTIES_PREFIX + ".enabled=false").run((context) -> {
+            assertThat(context).doesNotHaveBean(ActiveDirectoryAutoConfiguration.class);
+        });
+    }
+}


### PR DESCRIPTION
The @ConditionalOnProperty annotation lets configuration be included based on a Spring Environment property. See also https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-developing-auto-configuration.html

ActiveDirectoryAutoConfiguration is enabled if:
- security.activedirectory.enabled has the value true
- security.activedirectory.enabled is missing

ActiveDirectoryAutoConfiguration is disabled if:
- security.activedirectory.enabled has NOT the value true, e.g false.